### PR TITLE
feat(the-published-type-scanner-reads-code-not-prose): The published-ty…

### DIFF
--- a/.changeset/the-published-type-scanner-reads-code-not-prose.md
+++ b/.changeset/the-published-type-scanner-reads-code-not-prose.md
@@ -1,0 +1,13 @@
+---
+'@etherfold/core': patch
+---
+
+The published-type dependency scanner reads declarations rather than text.
+
+`packages/core/test/publishedTypeDependencies.test.ts` asserts that every package a published `.d.ts` imports from is a real dependency, which is a good claim: a type-only import is erased from the emitted `.js` but SURVIVES in the emitted `.d.ts`, so a package whose public types name `abitype` or `eip-1193` and declares neither is broken for whoever installs it. What was wrong was only HOW it read the file. It pattern-matched `from '...'` over the raw text, where a sentence is indistinguishable from a declaration, so a doc comment reading `nothing distinguishes "the chain had none" from "we never asked"` was reported as `core/dist/types.d.ts imports 'we never asked', which is not declared at all` and turned the acceptance gate red.
+
+A false positive that fails a gate is the expensive direction, and this one taught the wrong lesson: the author reworded the COMMENT to get past a test that was never about comments, in a repository whose whole documentation style is long explanatory comments. It would have recurred on every one of them.
+
+The scan now parses the declaration file with TypeScript (already a dependency here) and reads module specifiers out of the four positions a `.d.ts` can actually name a module in: `import`/`export ... from`, `import('x')` types, `import x = require('x')`, and a dynamic `import()` call. Those are positions no comment and no string literal can occupy. The claim is unchanged and a genuine undeclared import still fails with the same message.
+
+The only published change is a doc comment: `RangedAbiEvent`'s explanation of which way to err on `firstBlock` says `nothing distinguishes "the chain had none" from "we never asked"` again, which is the phrase used for this failure class everywhere else in the repo (ADR-0031, ADR-0033). Its presence in the emitted `dist/types.d.ts` is now what proves the scanner no longer cares.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -256,10 +256,10 @@ export type UntypedWireBatch = Omit<WireBatch<Abi>, 'logs'> & {logs: unknown[]};
  *
  * - **`firstBlock` too EARLY is safe**; too LATE loses logs undetectably. The
  *   blocks between the real first occurrence and the declared one are indexed
- *   without that event in the filter, so afterwards nothing distinguishes a
- *   chain that had no such log from a request that was never made. For a proxy
- *   deployment the implementation's own deploy block is naturally safe: an
- *   implementation cannot emit before it exists.
+ *   without that event in the filter, so afterwards nothing distinguishes "the
+ *   chain had none" from "we never asked". For a proxy deployment the
+ *   implementation's own deploy block is naturally safe: an implementation
+ *   cannot emit before it exists.
  * - **`lastBlock` too LATE is safe**; too EARLY loses logs the same way, and for
  *   the same reason. Omit it unless you know the event stopped.
  *

--- a/packages/core/test/publishedTypeDependencies.test.ts
+++ b/packages/core/test/publishedTypeDependencies.test.ts
@@ -1,6 +1,7 @@
 import {existsSync, readFileSync, readdirSync} from 'node:fs';
 import {isBuiltin} from 'node:module';
 import {join} from 'node:path';
+import ts from 'typescript';
 import {describe, expect, it} from 'vitest';
 
 /**
@@ -34,6 +35,11 @@ import {describe, expect, it} from 'vitest';
  * loud: a package that should have declarations but has none is a FAILURE rather
  * than a silent skip, and any artifact the build could not have produced is a
  * failure naming the stale file.
+ *
+ * A NOTE ON HOW IT READS IT. It PARSES. This was a text search once, and a text
+ * search cannot tell a declaration from a sentence that mentions one: a doc
+ * comment was read as a dependency and reddened the gate over prose. See the
+ * second `describe` below, which is the reading rule.
  */
 
 const PACKAGES = new URL('../../', import.meta.url).pathname;
@@ -62,16 +68,55 @@ function allFiles(dir: string): string[] {
 	});
 }
 
-/** Bare specifiers a declaration file imports or re-exports, including `import('x')` types. */
+/**
+ * Bare specifiers a declaration file imports or re-exports, including
+ * `import('x')` types, read out of the PARSE rather than out of the text.
+ *
+ * The four syntactic forms below are the whole of how a `.d.ts` can name another
+ * module, and each one is a node the parser hands us as a module specifier: a
+ * position no comment and no string literal can occupy. That is the entire point
+ * of parsing here. TypeScript is already a devDependency of this package, so the
+ * honest reading costs nothing beyond one `createSourceFile` per file.
+ *
+ * `declare module 'x' {}` is deliberately NOT counted: it augments or shims a
+ * module rather than importing one, and whatever really pulls that module in is
+ * an import this already reports. Nor is a triple-slash
+ * `/// <reference types="x" />`, which the text search never caught either;
+ * widening what the gate catches is a separate decision from fixing how it
+ * reads.
+ */
 function importedPackages(source: string): Set<string> {
 	const found = new Set<string>();
-	for (const pattern of [/(?:from|import)\s*\(?\s*'([^']+)'/g, /(?:from|import)\s*\(?\s*"([^"]+)"/g]) {
-		for (const match of source.matchAll(pattern)) {
-			const specifier = match[1];
-			if (specifier.startsWith('.') || isBuiltin(specifier)) continue;
-			found.add(packageOf(specifier));
-		}
+	// The name matters: it is what makes TypeScript parse this as a declaration
+	// file. `setParentNodes` stays off because nothing here walks upwards.
+	const parsed = ts.createSourceFile('scanned.d.ts', source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+
+	function record(node: ts.Node | undefined): void {
+		if (!node || !ts.isStringLiteralLike(node)) return;
+		const specifier = node.text;
+		if (specifier.startsWith('.') || isBuiltin(specifier)) return;
+		found.add(packageOf(specifier));
 	}
+
+	function visit(node: ts.Node): void {
+		if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+			// `import ... from 'x'`, `export ... from 'x'`, `export * from 'x'`.
+			record(node.moduleSpecifier);
+		} else if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
+			// `import('x').Type`, the form an inferred return type is emitted as, and
+			// the one most likely to name a package the author never typed.
+			record(node.argument.literal);
+		} else if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+			// `import x = require('x')`.
+			record(node.moduleReference.expression);
+		} else if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+			// `import('x')` as an expression, should one ever reach a declaration file.
+			record(node.arguments[0]);
+		}
+		ts.forEachChild(node, visit);
+	}
+
+	ts.forEachChild(parsed, visit);
 	return found;
 }
 
@@ -140,4 +185,92 @@ describe('published .d.ts files only import declared dependencies', () => {
 			).toEqual([]);
 		});
 	}
+});
+
+/**
+ * What the scan above COUNTS as an import, pinned directly.
+ *
+ * This used to be a text search, and a text search cannot tell a declaration
+ * from a sentence that mentions one. A doc comment reading `nothing
+ * distinguished "the chain had none" from "we never asked"` was reported as
+ * `core/dist/types.d.ts imports 'we never asked', which is not declared at all`,
+ * and the gate went red on a COMMENT. The author reworded the prose to get past
+ * it, which is the expensive lesson: it teaches people to change what a comment
+ * SAYS to satisfy a test that was never about comments, in a repository whose
+ * whole documentation style is long explanatory comments.
+ *
+ * So the cases below are the reading rule, not incidental examples. The first is
+ * the exact shape that broke it.
+ */
+describe('the scan reads declarations, not prose', () => {
+	it('ignores an import specifier written in JSDoc prose', () => {
+		const declaration = `
+/**
+ * A spliced event's logs were never asked for, and afterwards nothing
+ * distinguished "the chain had none" from "we never asked".
+ */
+export type Spliced = {topic0: string};
+`;
+		expect([...importedPackages(declaration)]).toEqual([]);
+	});
+
+	it('ignores an import written out inside an @example block', () => {
+		const declaration = `
+/**
+ * @example
+ * import {createIndexer} from 'left-pad';
+ * const indexer = createIndexer();
+ */
+export declare function createIndexer(): void;
+`;
+		expect([...importedPackages(declaration)]).toEqual([]);
+	});
+
+	it('ignores an import mentioned in a line comment', () => {
+		expect([...importedPackages(`// as in \`import x from 'left-pad'\`\nexport declare const x: number;\n`)]).toEqual(
+			[],
+		);
+	});
+
+	it('finds every form a declaration file really imports through', () => {
+		const declaration = `
+import type {Abi} from 'abitype';
+import {createClient} from 'viem/clients/createClient';
+export * from 'eip-1193';
+export type Logger = import('named-logs').Logger;
+export declare const later: () => Promise<typeof import('immer')>;
+`;
+		expect([...importedPackages(declaration)].sort()).toEqual(['abitype', 'eip-1193', 'immer', 'named-logs', 'viem']);
+	});
+
+	it('still ignores relative specifiers and node built-ins', () => {
+		const declaration = `
+import type {Local} from './local.js';
+import type {Buffer} from 'node:buffer';
+export type Held = {local: Local; buffer: Buffer};
+`;
+		expect([...importedPackages(declaration)]).toEqual([]);
+	});
+
+	it('does not count an import specifier that is merely the text of a string literal', () => {
+		// A string literal type is DATA, not a module reference: nothing resolves it,
+		// so a consumer missing that package is not broken by it. The old text search
+		// reported it; a parse cannot, and should not.
+		expect([...importedPackages(`export type Hint = "run: import x from 'left-pad'";\n`)]).toEqual([]);
+	});
+
+	it('reads the real emitted declarations rather than parsing them into nothing', () => {
+		// The failure mode of a parser-based scan is the silent one: a parse that
+		// yields no imports makes every package look clean. This package's public
+		// types are built out of `abitype` and `viem`, so an empty answer here means
+		// the scan stopped reading, not that the imports went away.
+		const found = new Set<string>();
+		for (const file of declarationFiles(join(PACKAGES, 'core', 'dist'))) {
+			for (const imported of importedPackages(readFileSync(file, 'utf-8'))) found.add(imported);
+		}
+		expect(
+			[...found],
+			'@etherfold/core\u2019s emitted declarations import nothing at all, which cannot be true',
+		).not.toEqual([]);
+	});
 });

--- a/work/notes/observations/source-scanning-gates-still-match-text-including-comments.md
+++ b/work/notes/observations/source-scanning-gates-still-match-text-including-comments.md
@@ -1,0 +1,16 @@
+---
+title: 'The source-scanning gates still match TEXT, so a comment can fail them'
+slug: source-scanning-gates-still-match-text-including-comments
+---
+
+2026-08-29, noticed while making `packages/core/test/publishedTypeDependencies.test.ts` parse
+instead of pattern-match. That was the only gate reading EMITTED output, but four more read `src/`
+the same way, and their whole-file matchers do not require an import at all: a COMMENT that
+mentions the forbidden thing fails them. `packages/state-store-sqlite/test/no-platform-leakage.test.ts`
+asserts `not.toMatch(/\bD1\b/)` and `not.toMatch(/cloudflare/i)` over the whole file, so explaining
+in a doc comment why this store must not name D1 would redden the gate; `stays-light.test.ts`,
+`stays-a-primitive.test.ts` and `packages/server/test/platformAgnostic.test.ts` do the same with
+`\bconsole\.` and `\bD1Database\b`. (Their `^\s*import ... from '...'` scans are anchored and much
+safer.) Separately, `packages/state-store-patch/test/historical-reads.test.ts` slices a method body
+out of `src/store.ts` by string index and regexes that, so a comment inside the body counts as code.
+Not touched: outside the task that found it.

--- a/work/tasks/done/the-published-type-scanner-reads-code-not-prose.md
+++ b/work/tasks/done/the-published-type-scanner-reads-code-not-prose.md
@@ -72,3 +72,9 @@ say so either way in your report rather than silently fixing one instance.
 >
 > Record any non-obvious in-scope decision in a `## Decisions` block in your final report, and do
 > not commit without confirmation.
+
+## Decisions
+
+**An import specifier that is only the TEXT of a string literal is no longer reported.** The old text search counted `export type Hint = "run: import x from 'left-pad'"`; a parse cannot, and I did not add a string-literal sweep to preserve that. A string literal type is data: nothing resolves it, so a consumer lacking that package is not broken by it, and counting it is the same false-positive class as counting a comment. The alternative (parse for declarations, then additionally regex string literals) reintroduces exactly the noise this task exists to remove, and cannot tell an illustrative snippet from anything else. Acceptance criterion 3 asked for this to be recorded. Touches only this test; nothing else consumes `importedPackages`.
+
+**The scan's COVERAGE is unchanged; only its reading changed.** A real parse could easily be widened to count `declare module 'x' {}` and triple-slash `/// <reference types="x" />`, both of which the text search never caught. I deliberately did not: widening what the gate catches is a different decision from fixing how it reads, and it can only turn packages red for reasons this task never examined (tsc emits `/// <reference types="node" />` on its own in some configurations). No dist file in the workspace currently contains either form. Recorded because a reviewer might reasonably expect "parse it properly" to imply "catch more"; it deliberately does not. Documented at the choice site in the `importedPackages` JSDoc.


### PR DESCRIPTION
Task: `work/tasks/done/the-published-type-scanner-reads-code-not-prose.md`

Done. The gate is green (`format:check`, `build`, `typecheck`, full `pnpm test` across the workspace).

## What I did

**Reproduced it first, exactly as specified.** Put a JSDoc comment carrying `from "we never asked"` on a type emitted into `packages/core/dist/types.d.ts`, built, and got:

```
core/dist/types.d.ts imports 'we never asked', which is not declared at all
```

**Failing test before the code.** Added a `describe('the scan reads declarations, not prose')` block to `packages/core/test/publishedTypeDependencies.test.ts` pinning the reading rule: the exact regression shape (a comment carrying `from "we never asked"`), an `@example` block containing a real-looking `import ... from 'left-pad'`, a line comment, an import specifier inside a string literal, the genuine forms that must still be found, and the relative/built-in skips. 5 of the 7 were red against the old regex.

**The fix: it parses now.** `importedPackages` builds a `ts.SourceFile` and reads module specifiers out of the four positions a `.d.ts` can actually name a module in (`import`/`export ... from`, `import('x')` types, `import x = require('x')`, a dynamic `import()` call). Those are positions no comment and no string literal can occupy. TypeScript was already a devDependency here, so this cost one `createSourceFile` per file.

**The claim survives.** I appended a genuine `import type {Whatever} from 'we-never-asked'` to the emitted `dist/types.d.ts` and the suite still fails with the identical message. I also added a guard test asserting the scan of core's real emitted declarations finds something, because the failure mode of a parser-based scan is the silent one (a parse that yields nothing makes every package look clean).

**Restored the reworded prose.** `RangedAbiEvent`'s doc in `packages/core/src/types.ts` had been softened to "nothing distinguishes a chain that had no such log from a request that was never made". It now reads `nothing distinguishes "the chain had none" from "we never asked"` again, the phrase used for this failure class everywhere else (ADR-0031, ADR-0033, `eventRanges.ts`, `LogEventFetcher.ts`). That sentence is emitted verbatim into `dist/types.d.ts`, so the live gate, not just a synthetic fixture, now proves the scanner does not care.

**Changeset:** `.changeset/the-published-type-scanner-reads-code-not-prose.md`, `@etherfold/core: patch`. Required regardless (the gate runs `changeset status --since=main` and `packages/core` is touched); the only published change is that doc comment. Note it currently still reports red locally only because the changeset file is untracked, and `@changesets/git` reads added changesets via `git diff` against the merge base; it counts once the runner commits.

## What else scans emitted output by pattern-matching text

Asked for either way, so: **nothing else reads `dist/`.** This was the only gate inspecting emitted output. I checked every `test/` directory, `scripts/`, and package sources for `dist/`, `.d.ts`, `readFileSync`, `matchAll` and `toMatch(`.

But **five tests read `src/` the same way**, and I left them alone (out of scope), capturing the signal in `work/notes/observations/source-scanning-gates-still-match-text-including-comments.md`:

- `packages/state-store-sqlite/test/no-platform-leakage.test.ts` is the worst of them: `not.toMatch(/\bD1\b/)` and `not.toMatch(/cloudflare/i)` over the whole file text, so a doc comment explaining *why* this store must not name D1 would redden the gate. Same defect, same incentive.
- `packages/state-store-patch/test/stays-light.test.ts`, `packages/state-store-indexeddb/test/stays-a-primitive.test.ts` and `packages/server/test/platformAgnostic.test.ts` do the same with `\bconsole\.`, `from ['"]node:` and `\bD1Database\b`.
- `packages/state-store-patch/test/historical-reads.test.ts` slices a method body out of `src/store.ts` by string index and regexes that; a comment inside the body counts as code.
- Their `^\s*import\s+...from\s+'...'` scans are line-anchored and much safer: a JSDoc line begins ` * `, so prose does not reach them. The whole-file matchers are the exposed ones.

## Decisions

**An import specifier that is only the TEXT of a string literal is no longer reported.** The old text search counted `export type Hint = "run: import x from 'left-pad'"`; a parse cannot, and I did not add a string-literal sweep to preserve that. A string literal type is data: nothing resolves it, so a consumer lacking that package is not broken by it, and counting it is the same false-positive class as counting a comment. The alternative (parse for declarations, then additionally regex string literals) reintroduces exactly the noise this task exists to remove, and cannot tell an illustrative snippet from anything else. Acceptance criterion 3 asked for this to be recorded. Touches only this test; nothing else consumes `importedPackages`.

**The scan's COVERAGE is unchanged; only its reading changed.** A real parse could easily be widened to count `declare module 'x' {}` and triple-slash `/// <reference types="x" />`, both of which the text search never caught. I deliberately did not: widening what the gate catches is a different decision from fixing how it reads, and it can only turn packages red for reasons this task never examined (tsc emits `/// <reference types="node" />` on its own in some configurations). No dist file in the workspace currently contains either form. Recorded because a reviewer might reasonably expect "parse it properly" to imply "catch more"; it deliberately does not. Documented at the choice site in the `importedPackages` JSDoc.