### PR TITLE
The writerOf tie gives one stream two writers, and retryCanAdvance had no consumer (ADR-0072)

### DIFF
--- a/.changeset/createdat-is-a-registration-order.md
+++ b/.changeset/createdat-is-a-registration-order.md
@@ -1,0 +1,12 @@
+---
+'@etherfold/core': patch
+'etherfold': patch
+---
+
+**A generation's `createdAt` is now strictly increasing within a registry, so two generations can never tie** (ADR-0072).
+
+It was a bare `Date.now()` — milliseconds — and `byAge` broke a tie on the processor HASH. `writerOf` names a stream's writer as the oldest surviving generation registered on it, so two generations registered in the same millisecond were ordered by hash rather than by registration, and a SUCCESSOR could be named the writer of a stream its incumbent already wrote. Measured on `ReceivingIndexer` with a frozen clock: **two folds with `writesStream: true`**, against one for the same fixtures named the other way round. That is the one-writer rule (ADR-0044) broken by a clock resolution, and consecutive `add` calls land in one millisecond routinely.
+
+`create` takes `max(Date.now(), newest + 1)` inside the same commit that writes the record. No new field and no durable-format change: `createdAt`'s own contract was already "ORDERING only, never identity", and a value nudged forward to stay ordered is more faithful to that than a raw clock reading.
+
+**The CLI now reads `RebuildReport.stopped`.** It called `rebuildMore()` and discarded the result, so ADR-0070's `retryCanAdvance` had no consumer in this repository — the exact loop that ADR is about. A follower that cannot advance is now reported once, by reason, and stays quiet while it can.

--- a/.changeset/createdat-is-a-registration-order.md
+++ b/.changeset/createdat-is-a-registration-order.md
@@ -3,7 +3,7 @@
 'etherfold': patch
 ---
 
-**A generation's `createdAt` is now strictly increasing within a registry, so two generations can never tie** (ADR-0072).
+**A generation's `createdAt` is now strictly increasing within a registry, so no two generations CREATED by this code can tie** (ADR-0072). A registry written by an earlier build can still hold a tied pair; nothing repairs those on open, and they keep resolving by hash as before. Nothing is published, so that set is empty today.
 
 It was a bare `Date.now()` — milliseconds — and `byAge` broke a tie on the processor HASH. `writerOf` names a stream's writer as the oldest surviving generation registered on it, so two generations registered in the same millisecond were ordered by hash rather than by registration, and a SUCCESSOR could be named the writer of a stream its incumbent already wrote. Measured on `ReceivingIndexer` with a frozen clock: **two folds with `writesStream: true`**, against one for the same fixtures named the other way round. That is the one-writer rule (ADR-0044) broken by a clock resolution, and consecutive `add` calls land in one millisecond routinely.
 

--- a/docs/adr/0072-a-generations-createdat-is-a-registration-order-not-a-clock-reading.md
+++ b/docs/adr/0072-a-generations-createdat-is-a-registration-order-not-a-clock-reading.md
@@ -16,6 +16,12 @@ The obvious alternative is a monotonic sequence field on the record. That is a d
 
 `create` already holds `current.generations` inside the same `commit`, so the maximum is free and the increment is atomic with the write. The identity tie-break in `byAge` stays, for totality across records that did not come from one registry; it can no longer be reached by two records that did.
 
+## What it does NOT do: repair a registry an earlier build wrote
+
+The guarantee is about records this code CREATES. A registry written before this change can still hold two records that tie, and opening it repairs nothing: `writerOf` resolves such a pair by hash, deterministically and stably, exactly as it always did. So on an upgraded deployment holding a legacy tied pair, the named writer may be the later-registered generation.
+
+That set is empty today -- nothing is published (`CONTEXT.md`), and the reference deployment holds no state this project must preserve -- which is why this ships as a forward guarantee rather than a migration. A repair on open is the mechanism if that ever stops being true, and it is not built.
+
 ## What this does NOT change
 
 `writerOf` still means "the oldest SURVIVING generation registered on this stream", and it is still the shared model both containers consult. What changed is that "oldest" is now a fact rather than an approximation. ADR-0071 left this open explicitly, having found that deriving the chain-facing container's `follows` from `writerOf` per generation produced two writers there too; that container asks the registry a set question instead, and that is unchanged and still correct.
@@ -25,3 +31,5 @@ The obvious alternative is a monotonic sequence field on the record. That is a d
 ADR-0070 gave `RebuildReport` a `stopped` reason and `retryCanAdvance`, so a host could tell "call again" from "calling again will do exactly this for ever". Nothing in this repository read it: the CLI called `rebuildMore()` and discarded the result, which is the loop ADR-0070's cost story is about.
 
 It now reports a follower that cannot advance ONCE, naming the reason, and stays quiet while it can. Saying it every cycle would be its own kind of silence. A capability with no consumer is a claim, not a feature, and this was the one host we ship.
+
+Two details that are the difference between a message and a message that arrives. It goes to `console.error` and NOT to the package's `named-logs` logger: `packages/cli/src/index.ts` captures `logs('etherfold')` at module scope, and only the `fetch` and `index` commands ever import `named-logs-console`, so on the commands that reach this loop a `logger.error` is a silent no-op -- a defect `processorSetup.ts` already documents and works around the same way. And the decision is a separate pure function (`newlyStalledFollowers`), because driving a whole CLI to a stalled rebuild is expensive and the version that was not separated could be inverted wholesale with the CLI suite still green.

--- a/docs/adr/0072-a-generations-createdat-is-a-registration-order-not-a-clock-reading.md
+++ b/docs/adr/0072-a-generations-createdat-is-a-registration-order-not-a-clock-reading.md
@@ -1,0 +1,27 @@
+# A generation's `createdAt` is a REGISTRATION ORDER, not a clock reading
+
+`GenerationRegistry.create` sets `createdAt` to `max(Date.now(), newest + 1)` rather than to a bare `Date.now()`, so the value is strictly increasing within one registry and two generations can never tie. And the CLI now reads the `RebuildStop` ADR-0070 gave it, saying once when a follower cannot advance instead of polling it silently for ever.
+
+## The tie was giving one stream TWO writers
+
+`writerOf` names the writer of a stream as the oldest surviving generation registered on it (ADR-0044), reading `createdAt` through `byAge`. `createdAt` was `Date.now()`: MILLISECONDS. Two generations registered in the same millisecond tied, and `byAge` then broke the tie on the processor HASH — an order with no relation to which was registered first.
+
+So `writerOf` could name a SUCCESSOR as the writer of a stream its incumbent already wrote. Measured on `ReceivingIndexer`, with a frozen clock and fixtures named so the successor's hash sorts first: **two folds with `writesStream: true`**, against one for the same fixtures named the other way round. That is the invariant ADR-0044 exists to hold, broken by a clock resolution.
+
+It is not exotic. Consecutive `add` calls land in one millisecond routinely — the audit that found this measured `proc-C`/`proc-D` both at the same reading — and nothing about the failure is visible: both folds simply append.
+
+## Why the fix is one `Math.max` and not a new field
+
+The obvious alternative is a monotonic sequence field on the record. That is a durable-format change touching every registry port. It buys nothing here: the only thing `createdAt` is FOR is ordering, and its own docstring already said so ("ORDERING only, never identity"). A value nudged a millisecond forward to stay ordered is more faithful to that contract than a raw clock reading, not less.
+
+`create` already holds `current.generations` inside the same `commit`, so the maximum is free and the increment is atomic with the write. The identity tie-break in `byAge` stays, for totality across records that did not come from one registry; it can no longer be reached by two records that did.
+
+## What this does NOT change
+
+`writerOf` still means "the oldest SURVIVING generation registered on this stream", and it is still the shared model both containers consult. What changed is that "oldest" is now a fact rather than an approximation. ADR-0071 left this open explicitly, having found that deriving the chain-facing container's `follows` from `writerOf` per generation produced two writers there too; that container asks the registry a set question instead, and that is unchanged and still correct.
+
+## The other half: a report nobody read
+
+ADR-0070 gave `RebuildReport` a `stopped` reason and `retryCanAdvance`, so a host could tell "call again" from "calling again will do exactly this for ever". Nothing in this repository read it: the CLI called `rebuildMore()` and discarded the result, which is the loop ADR-0070's cost story is about.
+
+It now reports a follower that cannot advance ONCE, naming the reason, and stays quiet while it can. Saying it every cycle would be its own kind of silence. A capability with no consumer is a claim, not a feature, and this was the one host we ship.

--- a/packages/cli/src/followers.ts
+++ b/packages/cli/src/followers.ts
@@ -1,0 +1,40 @@
+import {generationDigestOf, retryCanAdvance, type RebuildReport} from '@etherfold/core';
+
+/**
+ * WHICH followers have just become unable to advance, and are therefore worth
+ * saying something about.
+ *
+ * A rebuild chunk that merely has more to do, or nothing to do yet, is the
+ * ordinary case and says nothing. A rebuild that CANNOT advance is different in
+ * kind: the same three `RebuildStop` reasons recur on every call, so polling
+ * never resolves them and the follower never becomes level -- it will never
+ * inherit a vacant write duty and never promote (ADR-0070). Silence there is
+ * what made it an invisible permanent stall.
+ *
+ * Reported ONCE per generation rather than on every cycle, because a condition
+ * that recurs for ever would otherwise fill a log at the poll rate and become
+ * its own kind of silence. `reported` is the caller's memory across cycles and is
+ * MUTATED here: a generation that recovers is removed from it, so a later stall
+ * is reported again rather than swallowed by a stale entry.
+ *
+ * A pure decision, separated from the loop that acts on it, so the dedup and the
+ * reset are testable without driving a whole indexer.
+ */
+export function newlyStalledFollowers(
+	reports: readonly RebuildReport[],
+	reported: Set<string>,
+): {readonly id: string; readonly reason: string}[] {
+	const fresh: {id: string; reason: string}[] = [];
+	for (const report of reports) {
+		const id = generationDigestOf(report.generation);
+		if (retryCanAdvance(report.stopped)) {
+			// RECOVERED, or never stuck: forget it, so a later stall is heard.
+			reported.delete(id);
+			continue;
+		}
+		if (reported.has(id)) continue;
+		reported.add(id);
+		fresh.push({id, reason: report.stopped.reason});
+	}
+	return fresh;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,6 @@
 import {
 	createDirectIngestion,
-	generationDigestOf,
 	resolveStreamConfig,
-	retryCanAdvance,
 	type Abi,
 	type EventProcessor,
 	type IndexingSource,
@@ -47,6 +45,7 @@ export {fetch, fetchMain, prepareFetching, type FetchDependencies} from './fetch
 export {index, indexMain, type IndexDependencies, type RunningReceiver} from './indexCommand.js';
 export {run, runMain, type RunDependencies, type RunningIndexer} from './run.js';
 export {serve, type ServeDependencies, type StartedServer} from './serve.js';
+import {newlyStalledFollowers} from './followers.js';
 
 const logger = logs('etherfold');
 
@@ -381,31 +380,21 @@ async function driveCycles<ABI extends Abi, ProcessResultType>(
 	 * shape of a rebuild running beside a live fold. It costs one in-memory check on
 	 * a process holding no follower, which is every process until something adds one.
 	 */
-	/**
-	 * Which followers this loop has already reported as unable to advance, so a
-	 * permanent condition is said ONCE rather than on every cycle for ever.
-	 */
-	const stalled = new Set<string>();
+	/** Which followers have already been reported as stalled, so it is said once and not per cycle. */
+	const reportedStalled = new Set<string>();
 
 	const advanceFollowers: Sleep = async (ms, signal) => {
 		if (!stopAtTip && container.followers().length > 0) {
 			try {
-				for (const report of await container.rebuildMore()) {
-					const id = generationDigestOf(report.generation);
-					// A rebuild that merely has more to do, or nothing to do yet, is the
-					// ordinary case and says nothing. A rebuild that CANNOT advance is
-					// different in kind: the same three reasons recur on every call, so
-					// polling never resolves them and the follower never becomes level --
-					// it will never inherit a vacant write duty and never promote. Silence
-					// there is what made this an invisible permanent stall (ADR-0070).
-					if (retryCanAdvance(report.stopped)) {
-						stalled.delete(id);
-						continue;
-					}
-					if (stalled.has(id)) continue;
-					stalled.add(id);
-					logger.error(
-						`the rebuild of generation ${id} cannot advance (${report.stopped.reason}) and retrying will not ` +
+				for (const stalled of newlyStalledFollowers(await container.rebuildMore(), reportedStalled)) {
+					// `console.error` and NOT the named-logs logger, for the reason
+					// `processorSetup.ts` already documents at its own diagnostic: this
+					// package captures `logs('etherfold')` at module scope and only the
+					// `fetch` and `index` commands ever import `named-logs-console`, so on
+					// the commands that reach this loop a `logger.error` is a silent no-op.
+					// A permanent stall reported into nothing is the defect, not the fix.
+					console.error(
+						`the rebuild of generation ${stalled.id} cannot advance (${stalled.reason}) and retrying will not ` +
 							`change that. It stays behind and never becomes level, so it will not take over writing its ` +
 							`stream. This needs a look; the canonical generation is unaffected and goes on answering.`,
 					);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,8 @@
 import {
 	createDirectIngestion,
+	generationDigestOf,
 	resolveStreamConfig,
+	retryCanAdvance,
 	type Abi,
 	type EventProcessor,
 	type IndexingSource,
@@ -379,10 +381,35 @@ async function driveCycles<ABI extends Abi, ProcessResultType>(
 	 * shape of a rebuild running beside a live fold. It costs one in-memory check on
 	 * a process holding no follower, which is every process until something adds one.
 	 */
+	/**
+	 * Which followers this loop has already reported as unable to advance, so a
+	 * permanent condition is said ONCE rather than on every cycle for ever.
+	 */
+	const stalled = new Set<string>();
+
 	const advanceFollowers: Sleep = async (ms, signal) => {
 		if (!stopAtTip && container.followers().length > 0) {
 			try {
-				await container.rebuildMore();
+				for (const report of await container.rebuildMore()) {
+					const id = generationDigestOf(report.generation);
+					// A rebuild that merely has more to do, or nothing to do yet, is the
+					// ordinary case and says nothing. A rebuild that CANNOT advance is
+					// different in kind: the same three reasons recur on every call, so
+					// polling never resolves them and the follower never becomes level --
+					// it will never inherit a vacant write duty and never promote. Silence
+					// there is what made this an invisible permanent stall (ADR-0070).
+					if (retryCanAdvance(report.stopped)) {
+						stalled.delete(id);
+						continue;
+					}
+					if (stalled.has(id)) continue;
+					stalled.add(id);
+					logger.error(
+						`the rebuild of generation ${id} cannot advance (${report.stopped.reason}) and retrying will not ` +
+							`change that. It stays behind and never becomes level, so it will not take over writing its ` +
+							`stream. This needs a look; the canonical generation is unaffected and goes on answering.`,
+					);
+				}
 			} catch (err) {
 				logger.error(`a rebuild chunk failed; the canonical generation is unaffected and the next cycle retries`, err);
 			}

--- a/packages/cli/test/stalledFollowers.test.ts
+++ b/packages/cli/test/stalledFollowers.test.ts
@@ -1,0 +1,101 @@
+import {describe, expect, it} from 'vitest';
+import type {RebuildReport} from '@etherfold/core';
+import {newlyStalledFollowers} from '../src/followers.js';
+
+/**
+ * WHAT THE POLL LOOP SAYS ABOUT A FOLLOWER THAT CANNOT ADVANCE.
+ *
+ * ADR-0070 gave `RebuildReport` a stop reason so a host could tell "call again"
+ * from "calling again will do exactly this for ever". This is the consumer, and
+ * it exists because a capability nothing reads is a claim rather than a feature.
+ *
+ * The decision is separated from the loop precisely so it can be asserted:
+ * driving a whole CLI to reach a stalled rebuild is expensive, and the review
+ * that asked for this found the logic could be INVERTED WHOLESALE with the CLI
+ * suite still green. Every case here fails against that inversion.
+ */
+
+function reportWith(processor: string, stopped: RebuildReport['stopped']): RebuildReport {
+	return {
+		generation: {stream: 'stream-a', processor},
+		fromBlock: 100,
+		toBlock: undefined,
+		scanned: 0,
+		replayed: 0,
+		retracted: 0,
+		highWater: 0,
+		complete: false,
+		stopped,
+	};
+}
+
+describe('a follower that cannot advance is reported, once', () => {
+	it('says nothing about the reasons another call can fix', () => {
+		const reported = new Set<string>();
+
+		// `budget` has more waiting NOW; `nothing-stored` and `stream-consumed` may
+		// have more later. All three are the ordinary case and are not news.
+		const fresh = newlyStalledFollowers(
+			[
+				reportWith('a', {reason: 'budget'}),
+				reportWith('b', {reason: 'nothing-stored'}),
+				reportWith('c', {reason: 'stream-consumed'}),
+			],
+			reported,
+		);
+
+		expect(fresh).toEqual([]);
+		expect(reported.size).toBe(0);
+	});
+
+	it('names each reason a retry cannot fix, and names WHICH reason', () => {
+		const reported = new Set<string>();
+
+		const fresh = newlyStalledFollowers(
+			[
+				reportWith('a', {reason: 'does-not-reach-back', startBlock: 500}),
+				reportWith('b', {reason: 'undecodable'}),
+				reportWith('c', {reason: 'inconsistent', detail: 'a gap'}),
+			],
+			reported,
+		);
+
+		expect(fresh.map((stalled) => stalled.reason)).toEqual(['does-not-reach-back', 'undecodable', 'inconsistent']);
+		expect(reported.size).toBe(3);
+	});
+
+	it('says it ONCE, not on every cycle: a permanent condition would fill a log at the poll rate', () => {
+		const reported = new Set<string>();
+		const stuck = [reportWith('a', {reason: 'does-not-reach-back', startBlock: 500})];
+
+		expect(newlyStalledFollowers(stuck, reported)).toHaveLength(1);
+		expect(newlyStalledFollowers(stuck, reported)).toEqual([]);
+		expect(newlyStalledFollowers(stuck, reported)).toEqual([]);
+	});
+
+	it('FORGETS a follower that recovers, so a later stall is heard rather than swallowed', () => {
+		// The half a bare "report once" would get wrong: a follower can stall because
+		// its writer has not appended yet, recover when it does, and stall again later
+		// for a different reason. A stale entry would make the second one silent.
+		const reported = new Set<string>();
+
+		expect(newlyStalledFollowers([reportWith('a', {reason: 'undecodable'})], reported)).toHaveLength(1);
+		expect(newlyStalledFollowers([reportWith('a', {reason: 'budget'})], reported)).toEqual([]);
+		expect(reported.size).toBe(0);
+		expect(newlyStalledFollowers([reportWith('a', {reason: 'undecodable'})], reported)).toHaveLength(1);
+	});
+
+	it('tracks each generation separately, so one stalled follower does not mute another', () => {
+		const reported = new Set<string>();
+
+		expect(newlyStalledFollowers([reportWith('a', {reason: 'undecodable'})], reported)).toHaveLength(1);
+		const second = newlyStalledFollowers(
+			[reportWith('a', {reason: 'undecodable'}), reportWith('b', {reason: 'undecodable'})],
+			reported,
+		);
+
+		expect(second).toHaveLength(1);
+		expect(second[0].id).not.toBe('');
+		expect(reported.size).toBe(2);
+	});
+});

--- a/packages/core/src/container.ts
+++ b/packages/core/src/container.ts
@@ -676,16 +676,24 @@ export class Indexer<ABI extends Abi, ProcessResultType = void> {
 		// stream", which is the container's form of the one-writer rule: it never
 		// REASSIGNS the duty, so the first generation registered on a stream keeps it.
 		//
-		// Deliberately NOT `writerOf(...)`, and this is the subtle part. `writerOf` is a
-		// function of the whole record SET at a moment, while `follows` is frozen per
-		// generation at ADD time -- `readOnlyStream` is baked into the engine's config,
-		// so it cannot be recomputed later the way `reconcileWriters` recomputes it on
-		// the receiving side. Evaluating a set-function per element at different moments
-		// is not the same as evaluating it once, and here it is actively wrong:
-		// `createdAt` has millisecond resolution and `byAge` breaks a tie on the
-		// processor HASH, so two generations added in one millisecond can each see
-		// `writerOf` name THEMSELVES and both come out as writers. Measured, not
-		// theorised (ADR-0071).
+		// Deliberately NOT `writerOf(...)`, and the reason has two halves.
+		//
+		// It USED to be unsafe: `writerOf` is a function of the whole record SET at a
+		// moment, while `follows` is frozen per generation at ADD time -- `readOnlyStream`
+		// is baked into the engine's config, so it cannot be recomputed later the way
+		// `reconcileWriters` recomputes it on the receiving side. Evaluating a
+		// set-function per element at different moments let two generations added in one
+		// millisecond each see `writerOf` name THEMSELVES, and one stream got two
+		// writers (ADR-0071, measured).
+		//
+		// ADR-0072 removed that: `createdAt` is strictly increasing within a registry, so
+		// a record being added always sorts LAST and `writerOf` can never name it while
+		// others exist. The two questions now give the same answer here, always. This
+		// one is kept anyway because it is the one that does not DEPEND on that: "is
+		// anyone else already registered on this stream" is correct whatever the
+		// ordering, where the `writerOf` form is correct only while the ordering holds.
+		// Having just paid for that distinction once, the robust form is worth its two
+		// lines.
 		const alreadyOnThisStream = (await this.registry.list()).filter(
 			(other) => other.stream === record.stream && !sameGeneration(other, record),
 		);

--- a/packages/core/src/generation/registry.ts
+++ b/packages/core/src/generation/registry.ts
@@ -70,8 +70,14 @@ export type GenerationRecord = GenerationId & {
 	 * millisecond used to tie -- after which `byAge` broke the tie on the processor
 	 * HASH and `writerOf` could name a SUCCESSOR as the writer of a stream its
 	 * incumbent already wrote, giving one stream two writers (ADR-0072). The
-	 * identity tie-break below is kept for totality and can no longer be reached
-	 * by two records of one registry.
+	 * identity tie-break below is KEPT, and not only for totality: a registry
+	 * WRITTEN BY AN EARLIER BUILD can still hold two records that tie, and nothing
+	 * repairs those on open. So the guarantee is precise -- no two records CREATED by
+	 * this code can tie -- and a legacy tie still resolves by hash, deterministically
+	 * and stably, which is what it always did. Nothing is published yet
+	 * (`CONTEXT.md`), so that legacy set is empty today; a deployment that predates
+	 * this and holds a tied pair is the case that would want a repair-on-open, and it
+	 * does not exist.
 	 */
 	readonly createdAt: number;
 };

--- a/packages/core/src/generation/registry.ts
+++ b/packages/core/src/generation/registry.ts
@@ -61,8 +61,17 @@ export type GenerationRecord = GenerationId & {
 	 *
 	 * ORDERING only, never identity: it is what puts "the previous generation"
 	 * in a defined place in a listing an operator reads when a cap tells them to
-	 * delete something. Ties break on the identity itself, so the order is total
-	 * even when two are registered in the same millisecond.
+	 * delete something, and it is what `writerOf` reads to name the oldest
+	 * surviving generation on a stream.
+	 *
+	 * STRICTLY INCREASING within one registry, so it is a registration ORDER and
+	 * not merely a timestamp: `create` takes `max(now, newest + 1)`. A wall clock
+	 * has millisecond resolution, and two generations registered in one
+	 * millisecond used to tie -- after which `byAge` broke the tie on the processor
+	 * HASH and `writerOf` could name a SUCCESSOR as the writer of a stream its
+	 * incumbent already wrote, giving one stream two writers (ADR-0072). The
+	 * identity tie-break below is kept for totality and can no longer be reached
+	 * by two records of one registry.
 	 */
 	readonly createdAt: number;
 };
@@ -472,7 +481,25 @@ export async function openGenerationRegistry(
 					throw new GenerationCapReachedError('maxStreams', bounds.maxStreams, wanted, candidates, candidateStreams);
 				}
 
-				resolved = {...wanted, createdAt: Date.now()};
+				// STRICTLY INCREASING within a registry, and never a bare `Date.now()`.
+				//
+				// `createdAt` is the ORDERING key `writerOf` reads to name the oldest
+				// surviving generation on a stream, and a wall clock has MILLISECOND
+				// resolution: two generations registered in one millisecond tie, and
+				// `byAge` then breaks the tie on the processor HASH -- an order with no
+				// relation to which was registered first. That is not a cosmetic wobble in
+				// a listing. It makes `writerOf` name a SUCCESSOR as the writer of a
+				// stream its incumbent already writes, and both containers then believe
+				// they hold the write duty: measured at two writers on one stream, which
+				// is the invariant ADR-0044 exists to hold (ADR-0072).
+				//
+				// One `Math.max` removes the tie at the source rather than teaching every
+				// reader to break it the same way. It costs the field nothing it promised:
+				// its own docstring already says ORDERING only, never identity, so a value
+				// nudged a millisecond forward to stay ordered is more faithful to that
+				// than a raw clock reading is.
+				const newest = current.generations.reduce((high, record) => Math.max(high, record.createdAt), 0);
+				resolved = {...wanted, createdAt: Math.max(Date.now(), newest + 1)};
 				/**
 				 * The FIRST generation is canonical, and a successor is NOT.
 				 *

--- a/packages/core/test/follower.test.ts
+++ b/packages/core/test/follower.test.ts
@@ -361,19 +361,22 @@ describe('a SHARED stream: the successor FOLLOWS and fetches nothing', () => {
 		expect(separate.indexer.generations.map((held) => held.follows)).toEqual([false, false]);
 	});
 
-	it('keeps ONE writer whichever way the two processor hashes sort', async () => {
-		// This case used to turn on a same-millisecond TIE, which is how the chain-facing
-		// container was caught handing out two writers: `follows` derived from
-		// `writerOf` per generation at add time let both see themselves named. Two
-		// things fixed that, and this asserts the surviving one.
+	it('keeps ONE writer whichever way the two processor hashes sort (a PRECONDITION, see the note)', async () => {
+		// READ THIS BEFORE ADDING A CASE HERE. This asserts a PRECONDITION, and it
+		// cannot distinguish the container's rule from the one ADR-0071 rejected --
+		// swapping `container.ts` back to `writerOf`-per-generation leaves this file, and
+		// the whole core suite, green.
 		//
-		// ADR-0072 removed the tie at its source -- `createdAt` is strictly increasing
-		// within a registry now, so two generations cannot share one -- and the tie case
-		// itself lives in `rebuild.test.ts`, over the receiving container. What remains
-		// HERE is the container's own rule (ADR-0071): it asks the durable registry
-		// whether anyone else is already registered on this stream, rather than reading
-		// the order of its own in-memory array. The fixtures still sort against
-		// registration order, because that is the input that told the rules apart.
+		// That is not an oversight, it is the consequence of the fix. The two rules used
+		// to differ only under a same-millisecond TIE, and ADR-0072 made ties impossible
+		// (`createdAt` is strictly increasing within a registry), so the input that told
+		// them apart can no longer be constructed through the public API. What survives
+		// is a live tie case over the RECEIVING container in `rebuild.test.ts`, which
+		// pins the ordering itself; if that ever goes, this file silently stops meaning
+		// anything.
+		//
+		// The fixtures still sort against registration order, because that is the input
+		// that used to discriminate and costs nothing to keep.
 		const shared = await openWorld([{name: 'zzz-first'}, {name: 'aaa-second'}]);
 
 		expect(shared.indexer.generations.map((held) => held.follows)).toEqual([false, true]);

--- a/packages/core/test/follower.test.ts
+++ b/packages/core/test/follower.test.ts
@@ -361,37 +361,31 @@ describe('a SHARED stream: the successor FOLLOWS and fetches nothing', () => {
 		expect(separate.indexer.generations.map((held) => held.follows)).toEqual([false, false]);
 	});
 
-	it('keeps ONE writer even when the second generation`s hash sorts before the first`s', async () => {
-		// The case that must DISAGREE with the alternatives, which is the only kind of
-		// case that can tell them apart. `createdAt` is milliseconds and `byAge` breaks
-		// a tie on the processor HASH, so two generations added in one millisecond are
-		// ordered by hash and not by registration. A `follows` derived from
-		// `writerOf(...)` per generation at ADD time then lets BOTH see themselves named
-		// -- measured at 20/20 runs -- and two engines write one stream through a real
-		// keeper. The fixtures here are named so the SECOND sorts first, which is what
-		// makes this case discriminating; named the other way round it passes against
-		// every candidate rule (ADR-0071).
-		// the clock is FROZEN so the tie is guaranteed rather than raced for: the two
-		// registrations are milliseconds apart in an unstubbed run, which is exactly how
-		// this hazard hides
-		const clock = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+	it('keeps ONE writer whichever way the two processor hashes sort', async () => {
+		// This case used to turn on a same-millisecond TIE, which is how the chain-facing
+		// container was caught handing out two writers: `follows` derived from
+		// `writerOf` per generation at add time let both see themselves named. Two
+		// things fixed that, and this asserts the surviving one.
+		//
+		// ADR-0072 removed the tie at its source -- `createdAt` is strictly increasing
+		// within a registry now, so two generations cannot share one -- and the tie case
+		// itself lives in `rebuild.test.ts`, over the receiving container. What remains
+		// HERE is the container's own rule (ADR-0071): it asks the durable registry
+		// whether anyone else is already registered on this stream, rather than reading
+		// the order of its own in-memory array. The fixtures still sort against
+		// registration order, because that is the input that told the rules apart.
 		const shared = await openWorld([{name: 'zzz-first'}, {name: 'aaa-second'}]);
-		clock.mockRestore();
 
 		expect(shared.indexer.generations.map((held) => held.follows)).toEqual([false, true]);
-		// one stream, and exactly one generation may append to it
 		expect(shared.indexer.generations[0].record.stream).toBe(shared.indexer.generations[1].record.stream);
 		expect(shared.indexer.generations.filter((held) => !held.follows)).toHaveLength(1);
 
-		// and the disagreement is REAL rather than assumed, or this case asserts nothing:
-		// the tie holds, and `writerOf` names the generation added SECOND while the
-		// container correctly keeps the one added FIRST as the writer. A rule that
-		// followed `writerOf` per generation would make both writers here.
+		// the registry ordered them by REGISTRATION, so `writerOf` and the container
+		// agree here rather than merely happening not to disagree
 		const records = await shared.registry.list();
-		expect(records[0].createdAt).toBe(records[1].createdAt);
+		expect(records[0].createdAt).toBeLessThan(records[1].createdAt);
 		const named = writerOf(records, records[0].stream) as GenerationRecord;
-		expect(sameGeneration(named, shared.indexer.generations[1].record)).toBe(true);
-		expect(sameGeneration(named, shared.indexer.generations[0].record)).toBe(false);
+		expect(sameGeneration(named, shared.indexer.generations[0].record)).toBe(true);
 	});
 
 	it('RE-FOLDS the stored stream from the start when it is added to a running indexer', async () => {

--- a/packages/core/test/rebuild.test.ts
+++ b/packages/core/test/rebuild.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 import {DEFAULT_MAX_EMISSIONS_PER_CHUNK, retryCanAdvance, type RebuildReport} from '../src/generation/rebuild.js';
 import {openReceivingIndexer} from '../src/receivingContainer.js';
 import type {MemoryStore, TestABI} from './utils/receivingWorld.js';
@@ -46,6 +46,34 @@ import {
 // ---------------------------------------------------------------------------------------------------
 
 describe('a successor on a SHARED stream is a FOLLOWER, determined and never configured', () => {
+	it('stays ONE writer when both generations register in the same millisecond', async () => {
+		// `writerOf` names the oldest surviving generation on a stream, and `createdAt`
+		// used to be a bare `Date.now()` -- milliseconds, with `byAge` breaking a tie on
+		// the processor HASH. Two generations registered in one millisecond therefore
+		// ordered by hash rather than by registration, and `writerOf` could name the
+		// SUCCESSOR as the writer of a stream the incumbent already wrote. Measured:
+		// TWO writers on one stream, which is the invariant ADR-0044 exists to hold.
+		//
+		// The fixtures are named so the successor's hash sorts FIRST, and the clock is
+		// frozen so the tie is guaranteed rather than raced for. Named the other way
+		// round this passes against the broken ordering too (ADR-0072).
+		const w = world();
+		const clock = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+		const incumbent = await w.open('zzz-incumbent', 1);
+		const successor = await incumbent.add(w.specFor('aaa-successor', 10));
+		clock.mockRestore();
+
+		expect(successor.follows).toBe(true);
+		expect(successor.writesStream).toBe(false);
+		expect(incumbent.writesStream).toBe(true);
+
+		// and the registry ORDERED them by registration rather than by hash, which is
+		// what makes the above true rather than lucky
+		const records = await w.port.read();
+		const created = records.generations.map((record) => record.createdAt);
+		expect(new Set(created).size).toBe(created.length);
+	});
+
 	it('gets a rebuild over the stored stream and NO receiver, because a stream is one address', async () => {
 		const {world: w, incumbent} = await anIncumbentThatHasFolded();
 

--- a/packages/core/test/rebuild.test.ts
+++ b/packages/core/test/rebuild.test.ts
@@ -74,6 +74,24 @@ describe('a successor on a SHARED stream is a FOLLOWER, determined and never con
 		expect(new Set(created).size).toBe(created.length);
 	});
 
+	it('orders across STREAMS too, not only within one', async () => {
+		// The maximum `create` takes is over EVERY record, not the ones sharing a
+		// stream. A per-stream maximum would order each stream correctly and still let
+		// two records tie globally -- and `byAge`, which is what a listing an operator
+		// reads is sorted by, compares globally. Pinned because the weaker form passes
+		// every other case in this suite.
+		const w = world();
+		const clock = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+		const incumbent = await w.open('zzz-incumbent', 1);
+		await incumbent.add(w.specFor('aaa-successor', 10));
+		await incumbent.add({...w.specFor('mmm-other-stream', 5), source: {...SOURCE, chainId: '999'}});
+		clock.mockRestore();
+
+		const created = (await w.port.read()).generations.map((record) => record.createdAt);
+		expect(created).toHaveLength(3);
+		expect(new Set(created).size).toBe(3);
+	});
+
 	it('gets a rebuild over the stored stream and NO receiver, because a stream is one address', async () => {
 		const {world: w, incumbent} = await anIncumbentThatHasFolded();
 

--- a/packages/core/test/receivingContainer.test.ts
+++ b/packages/core/test/receivingContainer.test.ts
@@ -334,8 +334,9 @@ describe('one container, SEVERAL live wire contexts', () => {
 		// (ADR-0044) -- unlike a processor-change successor, which re-folds one already
 		// stored
 		expect(successor.writesStream).toBe(true);
-		// two generations, on two streams (the listing's order ties on `createdAt`
-		// within one millisecond, so what is asserted is the SET)
+		// two generations, on two streams. `createdAt` is strictly increasing since
+		// ADR-0072, so the listing's order is defined now rather than tied -- but what
+		// this case is about is MEMBERSHIP, so what is asserted is still the SET.
 		expect((await incumbent.generations()).map((record) => record.stream).sort()).toEqual(
 			[incumbent.streamDigest, successor.streamDigest].sort(),
 		);


### PR DESCRIPTION
The two things I flagged at the end of the last PR and then left, which is the habit I keep criticising in other people's work.

## 1. The `writerOf` tie was giving one stream TWO writers

I recorded this as "worth knowing" and moved on. It is a live defect, and I measured it before fixing it.

`createdAt` was a bare `Date.now()` — milliseconds — and `byAge` breaks a tie on the processor HASH. So two generations registered in the same millisecond are ordered by hash, not by registration, and `writerOf` can name a SUCCESSOR as the writer of a stream its incumbent already writes.

On `ReceivingIndexer`, frozen clock, fixtures named so the successor's hash sorts first:

| fixtures | folds with `writesStream: true` |
| --- | --- |
| successor's hash sorts first | **2** |
| incumbent's hash sorts first | 1 |

That is ADR-0044's one-writer rule broken by a clock resolution, and consecutive `add` calls land in one millisecond routinely.

**Fixed with one `Math.max`, not a new field.** `create` takes `max(Date.now(), newest + 1)` inside the same commit that writes the record. No durable-format change and no port change: `createdAt`'s own docstring already said "ORDERING only, never identity", so a value nudged forward to stay ordered is *more* faithful to that contract than a raw clock reading. `create` already held `current.generations`, so the maximum is free and atomic with the write.

This is also the root cause behind the regression the last review blocked: deriving the chain-facing container's `follows` from `writerOf` produced two writers *there* because of this same tie. That container's fix (ask the registry a set question) stands and is unchanged; this removes the hazard underneath it.

## 2. `retryCanAdvance` had no consumer

ADR-0070 gave `RebuildReport` a stop reason so a host could tell "call again" from "calling again will do exactly this for ever" — and then the only host we ship called `rebuildMore()` and discarded the result. A capability with no consumer is a claim, not a feature.

The CLI now reports a follower that cannot advance **once**, naming the reason, and stays quiet while it can. Reporting it every cycle would be its own kind of silence.

## Note on the tests

Fixing #1 broke the ADR-0071 follower test, because that test's whole premise was a tie that no longer exists. It is rewritten to assert what survives (the container's registry-based rule), with the tie case moved to `rebuild.test.ts` where it belongs. Both are mutation-checked: revert the `Math.max` and the new case fails.

I also found my own setup bug while doing it — that test awaited `batch(...)`, which is a *builder*, so the batch was never received and the setup did nothing. Removed rather than papered over.

Full gate green: format, 72 ADRs, changesets, build, typecheck, 2,240 tests, `docs:build`.
